### PR TITLE
API: correct usage of "get" API

### DIFF
--- a/test_lua.lua
+++ b/test_lua.lua
@@ -63,7 +63,7 @@ function test_put_and_get()
         code, message = db.put(name, key, value, ttl)
         assert(code == 0, message)
 
-        code, message, got_value = db.get(name, key, value)
+        code, message, got_value = db.get(name, key)
         assert(code == 0, message)
         assert(got_value == value, "value mistmach!")
 

--- a/tidesdb-lua.c
+++ b/tidesdb-lua.c
@@ -115,8 +115,8 @@ static int get(lua_State *L)
     const char* column_family = luaL_checkstring(L, 1);
     const uint8_t* key = (uint8_t*)luaL_checkstring(L, 2);
     const size_t key_size = (size_t)luaL_len(L, 2);
-    uint8_t* value = (uint8_t*)luaL_checkstring(L, 3);
-    size_t value_size = (size_t)luaL_len(L, 3);
+    uint8_t* value = NULL;
+    size_t value_size = 0;
     tidesdb_err_t *ret = tidesdb_get(db,
                                      column_family,
                                      key,


### PR DESCRIPTION
Fix get API call for not passing "value"
param