### PR TITLE
lua: refactor lua wrappers

### DIFF
--- a/test_lua.lua
+++ b/test_lua.lua
@@ -1,16 +1,16 @@
-local db = require("libtidesdb_lua")
+local lib = require("libtidesdb_lua")
 
 local code, message
 
-local directory = "/tmp"
+local directory = "tmp"
 local name = "my_db"
 local threshold = 1024*1024*64
 local max_skip_list = 12
 local prob_skip_list = 0.24
 local enable_compression = true
-local compression_algo = db.COMPRESS_SNAPPY
+local compression_algo = lib.COMPRESS_SNAPPY
 local enable_bloom_filter = true
-local db_data_struct = db.TDB_MEMTABLE_SKIP_LIST
+local db_data_struct = lib.TDB_MEMTABLE_SKIP_LIST
 
 local key = "key"
 local key_size = string.len(key)
@@ -19,17 +19,17 @@ local value_size = string.len(value)
 local ttl = 10
 
 function test_open_close()
-        code, message = db.open(directory)
+        code, message, db = lib.open(directory)
         assert(code == 0, message)
 
-        code, message = db.close()
+        code, message = lib.close(db)
         assert(code == 0, message)
 end
 
 function test_create_and_drop_column()
-        code, message = db.open(directory)
+        code, message, db = lib.open(directory)
         assert(code == 0, message)
-        code, message = db.create_column_family(name,
+        code, message = db:create_column_family(name,
                                                 threshold,
                                                 max_skip_list,
                                                 prob_skip_list,
@@ -39,18 +39,18 @@ function test_create_and_drop_column()
                                                 db_data_struct)
         assert(code == 0, message)
 
-        code, message = db.drop_column_family(name)
+        code, message = db:drop_column_family(name)
         assert(code == 0, message)
 
-        code, message = db.close()
+        code, message = lib.close(db)
         assert(code == 0, message)
 end
 
 function test_put_and_get()
-        code, message = db.open(directory)
+        code, message, db = lib.open(directory)
         assert(code == 0, message)
 
-        code, message = db.create_column_family(name,
+        code, message = db:create_column_family(name,
                                                 threshold,
                                                 max_skip_list,
                                                 prob_skip_list,
@@ -60,25 +60,25 @@ function test_put_and_get()
                                                 db_data_struct)
         assert(code == 0, message)
 
-        code, message = db.put(name, key, value, ttl)
+        code, message = db:put(name, key, value, ttl)
         assert(code == 0, message)
 
-        code, message, got_value = db.get(name, key)
+        code, message, got_value = db:get(name, key)
         assert(code == 0, message)
         assert(got_value == value, "value mistmach!")
 
-        code, message = db.drop_column_family(name)
+        code, message = db:drop_column_family(name)
         assert(code == 0, message)
 
-        code, message = db.close()
+        code, message = lib.close(db)
         assert(code == 0, message)
 end
 
 function test_put_and_delete()
-        code, message = db.open(directory)
+        code, message = lib.open(directory)
         assert(code == 0, message)
 
-        code, message = db.create_column_family(name,
+        code, message = db:create_column_family(name,
                                                 threshold,
                                                 max_skip_list,
                                                 prob_skip_list,
@@ -88,24 +88,24 @@ function test_put_and_delete()
                                                 db_data_struct)
         assert(code == 0, message)
 
-        code, message = db.put(name, key, value, ttl)
+        code, message = db:put(name, key, value, ttl)
         assert(code == 0, message)
 
-        code, message, got_value = db.delete(name, key)
+        code, message, got_value = db:delete(name, key)
         assert(code == 0, message)
 
-        code, message = db.drop_column_family(name)
+        code, message = db:drop_column_family(name)
         assert(code == 0, message)
 
-        code, message = db.close()
+        code, message = lib.close(db)
         assert(code == 0, message)
 end
 
 function test_put_and_compact()
-        code, message = db.open(directory)
+        code, message, db = lib.open(directory)
         assert(code == 0, message)
 
-        code, message = db.create_column_family(name,
+        code, message = db:create_column_family(name,
                                                 threshold,
                                                 max_skip_list,
                                                 prob_skip_list,
@@ -116,24 +116,51 @@ function test_put_and_compact()
         assert(code == 0, message)
 
         for i=1,20 do
-                code, message = db.put(name, i + '0', value, ttl)
+                code, message = db:put(name, i + '0', value, ttl)
                 assert(code == 0, message)
         end
 
-        code, message = db.compact_sstables(name, 2)
+        code, message = db:compact_sstables(name, 2)
 
-        code, message = db.drop_column_family(name)
+        code, message = db:drop_column_family(name)
         assert(code == 0, message)
 
-        code, message = db.close()
+        code, message = lib.close(db)
         assert(code == 0, message)
 end
 
 function test_list_column_families()
-        code, message = db.open(directory)
+        code, message, db = lib.open(directory)
         assert(code == 0, message)
 
-        code, message = db.create_column_family("one",
+        code, message = db:create_column_family("one",
+                                                threshold,
+                                                max_skip_list,
+                                                prob_skip_list,
+                                                enable_compression,
+                                                compression_algo,
+                                                enable_bloom_filter,
+                                                db_data_struct)
+        assert(code == 0, message)
+        assert(code == 0, message)
+
+        code, message, list = db:list_column_families()
+        assert(code == 0, message)
+        assert(list == "one\n")
+
+        code, message = db:drop_column_family("one")
+        assert(code == 0, message)
+
+
+        code, message = lib.close(db)
+        assert(code == 0, message)
+end
+
+function test_txn_begin_and_free()
+        code, message, db = lib.open(directory)
+        assert(code == 0, message)
+
+        code, message = db:create_column_family(name,
                                                 threshold,
                                                 max_skip_list,
                                                 prob_skip_list,
@@ -143,7 +170,23 @@ function test_list_column_families()
                                                 db_data_struct)
         assert(code == 0, message)
 
-        code, message = db.create_column_family("two",
+        code, message, txn = lib.txn_begin(db, name)
+        assert(code == 0, message)
+
+        code, message = txn:free()
+        assert(code == 0, message)
+
+        db:drop_column_family(name)
+        assert(code == 0, message)
+
+        lib.close(db)
+end
+
+function test_txn_put_and_delete()
+        code, message, db = lib.open(directory)
+        assert(code == 0, message)
+
+        code, message = db:create_column_family(name,
                                                 threshold,
                                                 max_skip_list,
                                                 prob_skip_list,
@@ -153,18 +196,22 @@ function test_list_column_families()
                                                 db_data_struct)
         assert(code == 0, message)
 
-        code, message, list = db.list_column_families()
-        assert(code == 0, message)
-        assert(list == "one\ntwo\n")
-
-        code, message = db.drop_column_family("one")
+        code, message, txn = lib.txn_begin(db, name)
         assert(code == 0, message)
 
-        code, message = db.drop_column_family("two")
+        code, message = txn:put(key, value, -1)
         assert(code == 0, message)
 
-        code, message = db.close()
+        code, message = txn:delete(key)
         assert(code == 0, message)
+
+        code, message = txn:free()
+        assert(code == 0, message)
+
+        db:drop_column_family(name)
+        assert(code == 0, message)
+
+        lib.close(db)
 end
 
 function test_all()
@@ -174,6 +221,8 @@ function test_all()
         test_put_and_delete()
         test_put_and_compact()
         test_list_column_families()
+        test_txn_begin_and_free()
+        test_txn_put_and_delete()
 end
 
 test_all()

--- a/tidesdb-lua.c
+++ b/tidesdb-lua.c
@@ -24,8 +24,6 @@
 #include <string.h>
 #include <tidesdb.h>
 
-static tidesdb_t *db = NULL;
-
 #define LUA_RET_CODE()                     \
     if(ret)                                \
     {                                      \
@@ -54,29 +52,97 @@ static tidesdb_t *db = NULL;
         return 3;                                      \
     }                                                  \
 
+
+static int db_open(lua_State *L);
+static int db_close(lua_State *L);
+static int create_column_family(lua_State *L);
+static int drop_column_family(lua_State *L);
+static int put(lua_State *L);
+static int get(lua_State *L);
+static int delete(lua_State *L);
+static int list_column_families(lua_State *L);
+static int compact_sstables(lua_State *L);
+
+static int txn_begin(lua_State *L);
+static int txn_put(lua_State *L);
+static int txn_delete(lua_State *L);
+static int txn_commit(lua_State *L);
+static int txn_rollback(lua_State *L);
+static int txn_free(lua_State *L);
+
+static const luaL_Reg regs_tidesdb_lib_lua[] = {
+    {"open", db_open},
+    {"close", db_close},
+    {"txn_begin", txn_begin},
+    {NULL, NULL},
+};
+
+static const luaL_Reg regs_tidesdb_lua[] = {
+    {"create_column_family", create_column_family},
+    {"drop_column_family", drop_column_family},
+    {"put", put},
+    {"get", get},
+    {"delete", delete},
+    {"compact_sstables", compact_sstables},
+    {"list_column_families", list_column_families},
+    {"txn_begin", txn_begin},
+    {NULL, NULL},
+};
+
+static const luaL_Reg regs_tidesdb_txn_lua[] = {
+    {"put", txn_put},
+    {"delete", txn_delete},
+    {"commit", txn_commit},
+    {"rollback", txn_rollback},
+    {"free", txn_free},
+    {NULL, NULL},
+};
+
 static int db_open(lua_State *L)
 {
     const char* directory = luaL_checkstring(L, 1);
+    tidesdb_t *db = NULL;
     tidesdb_err_t *ret = tidesdb_open(directory, &db);
-    LUA_RET_CODE()
+    if(ret) {
+        lua_pushinteger(L, ret->code);
+        lua_pushstring(L, ret->message);
+        tidesdb_err_free(ret);
+        return 2;
+    } else {
+
+        lua_pushinteger(L, 0);
+        lua_pushstring(L, "OK");
+
+        luaL_newlib(L, regs_tidesdb_lua);
+        lua_pushlightuserdata(L, db);
+        lua_setfield(L, -2, "self_db");
+        return 3;
+    }
 }
 
 static int db_close(lua_State *L)
 {
+    lua_getfield(L, -1, "self_db");
+    tidesdb_t *db = lua_touserdata(L, -1);
     tidesdb_err_t *ret = tidesdb_close(db);
     LUA_RET_CODE()   
 }
 
 static int create_column_family(lua_State *L)
 {
-    const char* column_family = luaL_checkstring(L, 1);
-    const int flush_threshold = luaL_checkinteger(L, 2);
-    const int max_skip_level = luaL_checkinteger(L, 3);
-    const float prob_skip_level = luaL_checknumber(L, 4);
-    const bool enable_compression = lua_toboolean(L, 5);
-    const tidesdb_compression_algo_t compression_algo = (tidesdb_compression_algo_t)luaL_checkinteger(L, 6);
-    const bool enable_bloom_filter = lua_toboolean(L, 7);
-    const tidesdb_memtable_ds_t db_data_struct = (tidesdb_memtable_ds_t)luaL_checkinteger(L, 8);
+
+    lua_getfield(L, 1, "self_db");
+    tidesdb_t *db = lua_touserdata(L, -1);
+    
+
+    const char* column_family = luaL_checkstring(L, 2);
+    const int flush_threshold = luaL_checkinteger(L, 3);
+    const int max_skip_level = luaL_checkinteger(L, 4);
+    const float prob_skip_level = luaL_checknumber(L, 5);
+    const bool enable_compression = lua_toboolean(L, 6);
+    const tidesdb_compression_algo_t compression_algo = (tidesdb_compression_algo_t)luaL_checkinteger(L, 7);
+    const bool enable_bloom_filter = lua_toboolean(L, 8);
+    const tidesdb_memtable_ds_t db_data_struct = (tidesdb_memtable_ds_t)luaL_checkinteger(L, 9);
     tidesdb_err_t *ret = tidesdb_create_column_family(db,
                                                       column_family,
                                                       flush_threshold,
@@ -86,23 +152,28 @@ static int create_column_family(lua_State *L)
                                                       compression_algo,
                                                       enable_bloom_filter,
                                                       db_data_struct);
-    LUA_RET_CODE()  
+    LUA_RET_CODE()
 }
 static int drop_column_family(lua_State *L)
 {
-    const char* column_family = luaL_checkstring(L, 1);
+    lua_getfield(L, 1, "self_db");
+    tidesdb_t *db = lua_touserdata(L, -1);
+    const char* column_family = luaL_checkstring(L, 2);
     tidesdb_err_t *ret = tidesdb_drop_column_family(db, column_family);
     LUA_RET_CODE()
 }
 
 static int put(lua_State *L)
 {
-    const char* column_family = luaL_checkstring(L, 1);
-    const uint8_t* key = (uint8_t*)luaL_checkstring(L, 2);
-    const size_t key_size = (size_t)luaL_len(L, 2);
-    const uint8_t* value = (uint8_t*)luaL_checkstring(L, 3);
-    const size_t value_size = (size_t)luaL_len(L, 3);
-    const int ttl = luaL_checkinteger(L, 4);
+    lua_getfield(L, 1, "self_db");
+    tidesdb_t *db = lua_touserdata(L, -1);
+
+    const char* column_family = luaL_checkstring(L, 2);
+    const uint8_t* key = (uint8_t*)luaL_checkstring(L, 3);
+    const size_t key_size = (size_t)luaL_len(L, 3);
+    const uint8_t* value = (uint8_t*)luaL_checkstring(L, 4);
+    const size_t value_size = (size_t)luaL_len(L, 4);
+    const int ttl = luaL_checkinteger(L, 5);
     tidesdb_err_t *ret = tidesdb_put(db,
                                      column_family,
                                      key,
@@ -115,9 +186,11 @@ static int put(lua_State *L)
 
 static int get(lua_State *L)
 {
-    const char* column_family = luaL_checkstring(L, 1);
-    const uint8_t* key = (uint8_t*)luaL_checkstring(L, 2);
-    const size_t key_size = (size_t)luaL_len(L, 2);
+    lua_getfield(L, 1, "self_db");
+    tidesdb_t *db = lua_touserdata(L, -1);
+    const char* column_family = luaL_checkstring(L, 2);
+    const uint8_t* key = (uint8_t*)luaL_checkstring(L, 3);
+    const size_t key_size = (size_t)luaL_len(L, 3);
     uint8_t* value = NULL;
     size_t value_size = 0;
     tidesdb_err_t *ret = tidesdb_get(db,
@@ -131,9 +204,12 @@ static int get(lua_State *L)
 
 static int delete(lua_State *L)
 {
-    const char* column_family = luaL_checkstring(L, 1);
-    const uint8_t* key = (uint8_t*)luaL_checkstring(L, 2);
-    const size_t key_size = (size_t)luaL_len(L, 2);
+    lua_getfield(L, 1, "self_db");
+    tidesdb_t *db = lua_touserdata(L, -1);
+    const char* column_family = luaL_checkstring(L, 2);
+    const uint8_t* key = (uint8_t*)luaL_checkstring(L, 3);
+    const size_t key_size = (size_t)luaL_len(L, 3);
+
     tidesdb_err_t *ret = tidesdb_delete(db,
                                         column_family,
                                         key,
@@ -143,8 +219,11 @@ static int delete(lua_State *L)
 
 static int compact_sstables(lua_State *L)
 {
-    const char* column_family = luaL_checkstring(L, 1);
-    const int max_threads = (uint32_t)luaL_checkinteger(L, 2);
+    lua_getfield(L, 1, "self_db");
+    tidesdb_t *db = lua_touserdata(L, -1);
+    const char* column_family = luaL_checkstring(L, 2);
+    const int max_threads = (uint32_t)luaL_checkinteger(L, 3);
+
     tidesdb_err_t *ret = tidesdb_compact_sstables(db,
                                         column_family,
                                         max_threads);
@@ -154,27 +233,94 @@ static int compact_sstables(lua_State *L)
 static int list_column_families(lua_State *L)
 {
     char* list = NULL;
+    lua_getfield(L, -1, "self_db");
+    tidesdb_t *db = lua_touserdata(L, -1);
     tidesdb_err_t *ret = tidesdb_list_column_families(db, &list);
     LUA_RET_CODE_AND_VALUE(list, strlen(list));
 }
 
+static int txn_begin(lua_State *L)
+{
+    const char* column_family = luaL_checkstring(L, 2);
+    tidesdb_txn_t *txn = NULL;
 
-static const luaL_Reg regs_tidesdb_lua[] = {
-    {"open", db_open},
-    {"close", db_close},
-    {"create_column_family", create_column_family},
-    {"drop_column_family", drop_column_family},
-    {"put", put},
-    {"get", get},
-    {"delete", delete},
-    {"compact_sstables", compact_sstables},
-    {"list_column_families", list_column_families},
-    {NULL, NULL}
-};
+    lua_getfield(L, -2, "self_db");
+    tidesdb_t *db = lua_touserdata(L, -1);
+    tidesdb_err_t *ret = tidesdb_txn_begin(db, &txn, column_family);
+    if(ret) {
+        lua_pushinteger(L, ret->code);
+        lua_pushstring(L, ret->message);
+        tidesdb_err_free(ret);
+        return 2;
+    } else {
+        lua_pushinteger(L, 0);
+        lua_pushstring(L, "OK");
+
+        lua_newtable(L);
+        luaL_setfuncs(L, regs_tidesdb_txn_lua, 0);
+        lua_pushlightuserdata(L, txn);
+        lua_setfield(L, -2, "self_txn");
+        return 3;
+    }
+}
+
+static int txn_put(lua_State *L)
+{
+    lua_getfield(L, 1, "self_txn");
+    tidesdb_txn_t *txn = lua_touserdata(L, -1);
+    const uint8_t* key = (uint8_t*)luaL_checkstring(L, 2);
+    const size_t key_size = (size_t)luaL_len(L, 2);
+    const uint8_t* value = (uint8_t*)luaL_checkstring(L, 3);
+    const size_t value_size = (size_t)luaL_len(L, 3);
+    const int ttl = luaL_checkinteger(L, 4);
+    tidesdb_err_t *ret = tidesdb_txn_put(txn,
+                                         key,
+                                         key_size,
+                                         value,
+                                         value_size,
+                                         ttl == -1 ? ttl : ttl + time(NULL));
+    LUA_RET_CODE()
+}
+
+static int txn_delete(lua_State *L)
+{
+    lua_getfield(L, 1, "self_txn");
+    tidesdb_txn_t *txn = lua_touserdata(L, -1);
+    const uint8_t* key = (uint8_t*)luaL_checkstring(L, 2);
+    const size_t key_size = (size_t)luaL_len(L, 2);
+    tidesdb_err_t *ret = tidesdb_txn_delete(txn,
+                                            key,
+                                            key_size);
+    LUA_RET_CODE()
+}
+
+static int txn_commit(lua_State *L)
+{
+    lua_getfield(L, -1, "self_txn");
+    tidesdb_txn_t *txn = lua_touserdata(L, -1);
+    tidesdb_err_t *ret = tidesdb_txn_commit(txn);
+    LUA_RET_CODE()
+}
+
+static int txn_rollback(lua_State *L)
+{
+    lua_getfield(L, -1, "self_txn");
+    tidesdb_txn_t *txn = lua_touserdata(L, -1);
+    tidesdb_err_t *ret = tidesdb_txn_rollback(txn);
+    LUA_RET_CODE()
+}
+
+static int txn_free(lua_State *L)
+{
+    lua_getfield(L, -1, "self_txn");
+    tidesdb_txn_t *txn = lua_touserdata(L, -1);
+    tidesdb_err_t *ret = tidesdb_txn_free(txn);
+    LUA_RET_CODE()
+}
 
 LUALIB_API int luaopen_libtidesdb_lua(lua_State *L)
 {
-    luaL_newlib(L, regs_tidesdb_lua);
+    luaL_newlib(L, regs_tidesdb_lib_lua);
 
     lua_pushnumber(L, 0);
     lua_setfield(L, -2, "NO_COMPRESSION");


### PR DESCRIPTION
Major rewriting lua wrappers:
now we use "lightuserdata" to properly keep
library C code pointers so now it could handle any
number of "tidesdb_open" instances

i.e. now it is possible to write

code, message, db1 = lib.open(directory1)
code, message, db2 = lib.open(directory2)

And dp1 / dp2 will keep their own context
separately - thus no more ugly global state pointers

Also added support for transaction APIs:

*tidesdb_txn_begin
*tidesdb_txn_put
*tidesdb_txn_delete
*tidesdb_txn_commit
*tidesdb_txn_rollback
*tidesdb_txn_free

+ tests for them

TODO: README update